### PR TITLE
fix wrong Certificate import from pkijs + move @types/pkijs from "devDependencies" to "dependencies"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "t1c-sdk-js",
-  "version": "3.1.4-SNAPSHOT",
+  "version": "3.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -4112,7 +4112,6 @@
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/@types/asn1js/-/asn1js-0.0.2.tgz",
       "integrity": "sha512-xtLPq140WhPqvDZDpY70rTx4qTezHs+8htbhWQGuevBRQko8FRjFSO5WVTwXOwd3W5tQRxJ7eni30fDUP2q4wQ==",
-      "dev": true,
       "requires": {
         "@types/pvutils": "*"
       }
@@ -4330,7 +4329,6 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/@types/pkijs/-/pkijs-0.0.3.tgz",
       "integrity": "sha512-WLxDUWFx1hmaY2aEE0PQL9zYT1K30pG7O9pEN15KXS4xHdh+16/fO3UoRKGLW7wVMiONjZgUu0gtVA+prjmS/Q==",
-      "dev": true,
       "requires": {
         "@types/asn1js": "*",
         "@types/pvutils": "*"
@@ -4351,8 +4349,7 @@
     "@types/pvutils": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/@types/pvutils/-/pvutils-0.0.2.tgz",
-      "integrity": "sha512-CgQAm7pjyeF3Gnv78ty4RBVIfluB+Td+2DR8iPaU0prF18pkzptHHP+DoKPfpsJYknKsVZyVsJEu5AuGgAqQ5w==",
-      "dev": true
+      "integrity": "sha512-CgQAm7pjyeF3Gnv78ty4RBVIfluB+Td+2DR8iPaU0prF18pkzptHHP+DoKPfpsJYknKsVZyVsJEu5AuGgAqQ5w=="
     },
     "@types/sha256": {
       "version": "0.2.0",
@@ -13068,6 +13065,30 @@
           "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
           "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
           "dev": true
+        }
+      }
+    },
+    "pkijs": {
+      "version": "2.1.41",
+      "resolved": "https://registry.npmjs.org/pkijs/-/pkijs-2.1.41.tgz",
+      "integrity": "sha512-fqnpBSIfnSL2cfKJA4kWDQtnwc0FgfgkOCXoA3bPWBmWtGZ9Sd/5OXe/MGcV/Fa13xSE573Pt8QA4qN+lkOrSg==",
+      "requires": {
+        "asn1js": "^2.0.26",
+        "pvutils": "^1.0.17"
+      },
+      "dependencies": {
+        "asn1js": {
+          "version": "2.0.26",
+          "resolved": "https://registry.npmjs.org/asn1js/-/asn1js-2.0.26.tgz",
+          "integrity": "sha512-yG89F0j9B4B0MKIcFyWWxnpZPLaNTjCj4tkE3fjbAoo0qmpGw0PYYqSbX/4ebnd9Icn8ZgK4K1fvDyEtW1JYtQ==",
+          "requires": {
+            "pvutils": "^1.0.17"
+          }
+        },
+        "pvutils": {
+          "version": "1.0.17",
+          "resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.0.17.tgz",
+          "integrity": "sha512-wLHYUQxWaXVQvKnwIDWFVKDJku9XDCvyhhxoq8dc5MFdIlRenyPI9eSfEtcvgHgD7FlvCyGAlWgOzRnZD99GZQ=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "@types/jwt-decode": "^2.2.1",
     "@types/moment": "^2.13.0",
     "@types/node": "^13.11.1",
-    "@types/pkijs": "^0.0.3",
     "@types/platform": "^1.3.2",
     "@types/sha256": "^0.2.0",
     "@types/uuid": "^7.0.3",
@@ -65,6 +64,7 @@
   },
   "dependencies": {
     "@types/lodash": "^4.14.150",
+    "@types/pkijs": "^0.0.3",
     "Base64": "^1.1.0",
     "axios": "^0.19.2",
     "jsencrypt": "^3.0.0-rc.1",

--- a/src/scripts/core/service/CoreModel.ts
+++ b/src/scripts/core/service/CoreModel.ts
@@ -1,6 +1,6 @@
 import {T1CLibException} from '../exceptions/CoreExceptions';
 import {T1CClient} from '../T1CSdk';
-import Certificate from 'pkijs/build/Certificate';
+import Certificate from 'pkijs/src/Certificate';
 
 export interface AbstractCore {
   // getConsent(title: string, codeWord: string, durationInDays?: number, alertLevel?: string, alertPosition?: string, type?: string, timeoutInSeconds?: number, callback?: (error: T1CLibException, data: BoolDataResponse) => void): Promise<BoolDataResponse>;

--- a/src/scripts/modules/pkcs11/pkcs11Object/Pkcs11Model.ts
+++ b/src/scripts/modules/pkcs11/pkcs11Object/Pkcs11Model.ts
@@ -3,7 +3,7 @@ import {
     DataObjectResponse
 } from '../../../core/service/CoreModel';
 import {Pkcs11Info, Pkcs11Slot, Pkcs11TokenInfo} from "../../../..";
-import Certificate from 'pkijs/build/Certificate';
+import Certificate from 'pkijs/src/Certificate';
 
 
 

--- a/src/scripts/util/CertParser.ts
+++ b/src/scripts/util/CertParser.ts
@@ -1,6 +1,6 @@
 import * as asn1js from 'asn1js';
 import * as Base64 from 'Base64';
-import Certificate from 'pkijs/build/Certificate';
+import Certificate from 'pkijs/src/Certificate';
 import { T1CLibException } from '../core/exceptions/CoreExceptions';
 import {
     TokenCertificateResponse,


### PR DESCRIPTION
Fix incorrect `import Certificate from 'pkijs/build/Certificate';` in 3 ts files.
The defined type in "node_modules/@types/pkijs/index.d.ts" is 
```ts
declare module "pkijs/src/Certificate" {
  // ...
}
```
This fix the issue with `any` type in generated Pkcs11Model.d.ts

\+ Move `"@types/pkijs"` from devDeps to dependencies in package.json to make it available to users of "t1c-sdk-js" as it is the case for `"@types/lodash"`